### PR TITLE
Fix React import lint errors

### DIFF
--- a/onboarding-frontend/src/App.tsx
+++ b/onboarding-frontend/src/App.tsx
@@ -1,5 +1,4 @@
 // src/App.tsx
-import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Layout from './components/Layout';
 import Home from './pages/Home';

--- a/onboarding-frontend/src/components/AdminPanel.tsx
+++ b/onboarding-frontend/src/components/AdminPanel.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+import type { FC } from 'react';
 
 type ComponentConfig = {
   id?: number;
@@ -10,7 +11,7 @@ type ComponentConfig = {
  * AdminPanel component allows configuring onboarding steps,
  * fetching and updating component configuration from backend.
  */
-const AdminPanel: React.FC = () => {
+const AdminPanel: FC = () => {
   const [components, setComponents] = useState<ComponentConfig[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/onboarding-frontend/src/components/Footer.tsx
+++ b/onboarding-frontend/src/components/Footer.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import type { FC } from 'react';
 
 /**
  * Footer component displaying copyright info.
  */
-const Footer: React.FC = () => {
+const Footer: FC = () => {
   return (
     <footer className="footer" role="contentinfo">
       <p>&copy; {new Date().getFullYear()} Onboarding App. All rights reserved.</p>

--- a/onboarding-frontend/src/components/Header.tsx
+++ b/onboarding-frontend/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { FC } from 'react';
 
 type HeaderProps = {
   toggleSidebar: () => void;
@@ -8,7 +8,7 @@ type HeaderProps = {
 /**
  * Header component with a toggle button to open/close sidebar.
  */
-const Header: React.FC<HeaderProps> = ({ toggleSidebar, isSidebarOpen }) => {
+const Header: FC<HeaderProps> = ({ toggleSidebar, isSidebarOpen }) => {
   return (
     <header className="header">
       <button

--- a/onboarding-frontend/src/components/Layout.tsx
+++ b/onboarding-frontend/src/components/Layout.tsx
@@ -1,18 +1,19 @@
 // src/components/Layout.tsx
-import React, { useState, useCallback } from 'react';
+import { useState, useCallback } from 'react';
+import type { FC, ReactNode } from 'react';
 import Header from './Header';
 import Sidebar from './Sidebar';
 import Footer from './Footer';
 
 type LayoutProps = {
-  children: React.ReactNode;
+  children: ReactNode;
 };
 
 /**
  * Layout component that wraps the application.
  * Manages sidebar open/collapse state and renders Header, Sidebar, Content, and Footer.
  */
-const Layout: React.FC<LayoutProps> = ({ children }) => {
+const Layout: FC<LayoutProps> = ({ children }) => {
   // Sidebar open state
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
 

--- a/onboarding-frontend/src/components/OnboardingPage2.tsx
+++ b/onboarding-frontend/src/components/OnboardingPage2.tsx
@@ -1,4 +1,4 @@
-import React, { type ChangeEvent, type FormEvent } from 'react';
+import type { ChangeEvent, FormEvent, FC } from 'react';
 
 /**
  * UserData holds the user input values for onboarding step 2.
@@ -36,7 +36,7 @@ interface OnboardingPage2Props {
  * Renders dynamic fields based on components prop,
  * handles controlled inputs and form submission.
  */
-const OnboardingPage2: React.FC<OnboardingPage2Props> = ({
+const OnboardingPage2: FC<OnboardingPage2Props> = ({
   userData,
   components,
   onUserDataChange,

--- a/onboarding-frontend/src/components/OnboardingWizard.tsx
+++ b/onboarding-frontend/src/components/OnboardingWizard.tsx
@@ -1,5 +1,6 @@
 // src/components/OnboardingWizard.tsx
-import React, { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
+import type { FC } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { validateEmail, validatePassword } from '../utils/validators';
 
@@ -27,7 +28,7 @@ const TOTAL_STEPS = 3;
 const CONFIG_ENDPOINT = '/api/admin/config';
 const USER_ENDPOINT = '/api/users';
 
-const OnboardingWizard: React.FC = () => {
+const OnboardingWizard: FC = () => {
   const [userData, setUserData] = useState<UserData>({ email: '', password: '' });
   const [currentStep, setCurrentStep] = useState<number>(1);
   const [userId, setUserId] = useState<number | null>(null);
@@ -46,8 +47,12 @@ const OnboardingWizard: React.FC = () => {
       if (!response.ok) throw new Error('Failed to load component configuration');
       const data: ComponentConfig[] = await response.json();
       setComponents(data);
-    } catch (err: any) {
-      setError(err.message || 'Error loading component configuration');
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError('Error loading component configuration');
+      }
     }
   }, []);
 
@@ -114,8 +119,12 @@ const OnboardingWizard: React.FC = () => {
 
       setUserId(data.id);
       setCurrentStep(2);
-    } catch (err: any) {
-      setError(err.message || 'Something went wrong. Please try again.');
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError('Something went wrong. Please try again.');
+      }
     } finally {
       setLoading(false);
     }
@@ -146,8 +155,12 @@ const OnboardingWizard: React.FC = () => {
       } else {
         setCompleted(true);
       }
-    } catch (err: any) {
-      setError(err.message || 'Something went wrong while saving.');
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError('Something went wrong while saving.');
+      }
     } finally {
       setLoading(false);
     }

--- a/onboarding-frontend/src/components/Sidebar.tsx
+++ b/onboarding-frontend/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 // src/components/Sidebar.tsx
-import React from 'react';
+import type { FC } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 
 type SidebarProps = {
@@ -10,7 +10,7 @@ type SidebarProps = {
  * Sidebar component with collapsible behavior.
  * Shows navigation links with icons.
  */
-const Sidebar: React.FC<SidebarProps> = ({ isOpen }) => {
+const Sidebar: FC<SidebarProps> = ({ isOpen }) => {
   const location = useLocation();
 
   // Define menu items once — easy to maintain and extend

--- a/onboarding-frontend/src/components/UserDataTable.tsx
+++ b/onboarding-frontend/src/components/UserDataTable.tsx
@@ -1,11 +1,12 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback } from 'react';
+import type { FC } from 'react';
 
 interface User {
   id: number;
   email: string;
 }
 
-const UserDataTable: React.FC = () => {
+const UserDataTable: FC = () => {
   const [users, setUsers] = useState<User[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);

--- a/onboarding-frontend/src/pages/Home.tsx
+++ b/onboarding-frontend/src/pages/Home.tsx
@@ -1,11 +1,11 @@
 // src/pages/Home.tsx
-import React from 'react';
+import type { FC } from 'react';
 
 /**
  * Home page component - serves as the landing page of the Onboarding App.
  * Provides a brief welcome message and introduction.
  */
-const Home: React.FC = () => {
+const Home: FC = () => {
   return (
     <main role="main" className="page-wrapper">
       <h2 tabIndex={-1}>Welcome to the Onboarding App</h2>


### PR DESCRIPTION
## Summary
- clean up unused default React imports
- fix linter complaints about `any` usage in `OnboardingWizard`

## Testing
- `npm run lint`
- `npm run build`
- `npm test` (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_687da8ddac4c8320b688d69903a319ab